### PR TITLE
Feature/fix auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 4.1'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.12'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    bcrypt (3.1.15)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -71,7 +72,7 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.6.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -124,7 +125,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    spring (2.1.0)
+    spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -149,6 +150,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.12)
   bootsnap (>= 1.4.2)
   byebug
   listen (~> 3.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,23 +1,11 @@
 class ApplicationController < ActionController::API
-  include ActionController::HttpAuthentication::Token::ControllerMethods
-  before_action :auth
+  include ActionController::Helpers
+  before_action :current_user
+  helper_method :current_user
 
-  # def set_current_user
-  #   @current_user = User.find_by(token: params[:token])
-  # end
-
-  # auth_tokenか401を返却する。
-  # このアクションをapp_controllerで実行しているので、グローバルに適用される。
-  def auth
-    auth_token || render(json: { error: :unauthorized }, status: 401)
-  end
-
-  # token, optionsの入ったブロックを渡してtokenをチェック。
-  # tokenでuserを検索してcurrent_userを設定し、current_userを返却
-  def auth_token
-    authenticate_with_http_token do |token, options|
-      @current_user = User.find_by(token: token)
-      !!@current_user
+  def current_user
+    if session[:user_id]
+      @current_user ||= User.find_by(id: session[:user_id])
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::API
   def current_user
     if session[:user_id]
       @current_user ||= User.find_by(id: session[:user_id])
+    else
+      puts 'No currentUser'
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,24 @@
 class ApplicationController < ActionController::API
-  before_action :set_current_user
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+  before_action :auth
 
-  def set_current_user
-    @current_user = User.find_by(token: params[:token])
+  # def set_current_user
+  #   @current_user = User.find_by(token: params[:token])
+  # end
+
+  # auth_tokenか401を返却する。
+  # このアクションをapp_controllerで実行しているので、グローバルに適用される。
+  def auth
+    auth_token || render(json: { error: :unauthorized }, status: 401)
   end
 
+  # token, optionsの入ったブロックを渡してtokenをチェック。
+  # tokenでuserを検索してcurrent_userを設定し、current_userを返却
+  def auth_token
+    authenticate_with_http_token do |token, options|
+      @current_user = User.find_by(token: token)
+      !!@current_user
+    end
+  end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,9 +8,13 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.new(content: params[:content], user_id: @current_user.id)
-    @post.save
-    render json: @post
+    if !@current_user
+      puts 'okokokoko'
+    else
+      @post = Post.new(content: params[:content], user_id: @current_user.id)
+      @post.save
+      render json: @post
+    end
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,6 +11,7 @@ class PostsController < ApplicationController
     if !@current_user
       puts 'okokokoko'
     else
+      puts @current_user
       @post = Post.new(content: params[:content], user_id: @current_user.id)
       @post.save
       render json: @post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,14 +8,10 @@ class PostsController < ApplicationController
   end
 
   def create
-    if !@current_user
-      puts 'okokokoko'
-    else
-      puts @current_user
-      @post = Post.new(content: params[:content], user_id: @current_user.id)
-      @post.save
-      render json: @post
-    end
+    puts @current_user
+    @post = Post.new(content: params[:content], user_id: @current_user.id)
+    @post.save
+    render json: @post
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,10 @@
 class UsersController < ApplicationController
-  skip_before_action :auth, only: [:create, :login]
 
   def create
     #あとでuser_paramsに変える
     @user = User.new(uid: params[:uid],name: params[:name], password: params[:password], password_confirmation: params[:password_confirmation])
     @user.save
-    puts 'ok'
-    @current_user = @user
+    session[:token] = @user.id
     render json: {
       user: @user,
       token: @user.token
@@ -36,11 +34,13 @@ class UsersController < ApplicationController
 
   def login
     @user = User.find_by(uid: params[:uid])
-    # このしたでエラー
     if @user&.authenticate(params[:password])
+      session[:user_id] = @user.id
+      puts 'yaaaaaaay'
+      puts session[:user_id]
+      #ここまで出力される=sessionにちゃんと入ってる
       render json: {
-        user: @user,
-        token: @user.token
+        user: @user
       }
     else
       render json: {
@@ -64,6 +64,7 @@ class UsersController < ApplicationController
 
   def logout
     session[:user_id] = nil
+    @current_user = nil
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,11 @@
 class UsersController < ApplicationController
-  skip_before_action :set_current_user, [:login], raise: false
+  skip_before_action :auth, only: [:create, :login]
 
   def create
-    @user = User.new(name: params[:name], password: params[:password])
+    #あとでuser_paramsに変える
+    @user = User.new(uid: params[:uid],name: params[:name], password: params[:password], password_confirmation: params[:password_confirmation])
     @user.save
-    # あとでPost一覧に指定　→　redirect_to("/users/#{@user.id}")
-    session[:user_id] = @user.id
+    puts 'ok'
     @current_user = @user
     render json: {
       user: @user,
@@ -34,22 +34,41 @@ class UsersController < ApplicationController
     }
   end
 
-
   def login
-    @user = User.find_by(uid: params[:uid], password: params[:password])
-    if @user
-      @current_user = @user.id
+    @user = User.find_by(uid: params[:uid])
+    # このしたでエラー
+    if @user&.authenticate(params[:password])
       render json: {
         user: @user,
         token: @user.token
       }
     else
-      render status: 401
+      render json: {
+        status: 401
+      }
     end
   end
 
+  # def login
+  #   @user = User.find_by(uid: params[:uid], password: params[:password])
+  #   if @user
+  #     @current_user = @user.id
+  #     render json: {
+  #       user: @user,
+  #       token: @user.token
+  #     }
+  #   else
+  #     render status: 401
+  #   end
+  # end
+
   def logout
     session[:user_id] = nil
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:name, :uid, :password, :password_confirmation)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_secure_token
+  has_secure_password
 
   has_many :posts, dependent: :destroy
   has_many :likes

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,8 @@ module Tanker
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
+    
+    # trueをfalseに変更 by Lin
+    config.api_only = false
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,10 +1,12 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
     allow do
-      origins "*"
-  
+      # 許可するドメイン
+      origins "http://localhost:8080"
+      # 許可するヘッダーとメソッドの種類
       resource "*",
         headers: :any,
         methods: [:get, :post, :put, :patch, :delete, :options, :head],
-        expose: ['Per-Page', 'Total', 'Link']
+        expose: ['Per-Page', 'Total', 'Link'],
+        credentials: true
     end
   end

--- a/db/migrate/20200827041953_add_password_digest_to_users.rb
+++ b/db/migrate/20200827041953_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :password_digest, :integer
+  end
+end

--- a/db/migrate/20200827042133_remove_password_from_users.rb
+++ b/db/migrate/20200827042133_remove_password_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :password, :integer
+  end
+end

--- a/db/migrate/20200827072548_remove_digest_from_users.rb
+++ b/db/migrate/20200827072548_remove_digest_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveDigestFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :password_digest, :integer
+  end
+end

--- a/db/migrate/20200827072850_add_digest_to_users.rb
+++ b/db/migrate/20200827072850_add_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddDigestToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_031334) do
+ActiveRecord::Schema.define(version: 2020_08_27_072850) do
 
   create_table "follows", force: :cascade do |t|
     t.integer "follower_id"
@@ -36,7 +36,6 @@ ActiveRecord::Schema.define(version: 2020_08_25_031334) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
-    t.string "password"
     t.boolean "is_admin", default: false
     t.string "uid"
     t.string "image_name", default: "default.jpg"
@@ -44,6 +43,7 @@ ActiveRecord::Schema.define(version: 2020_08_25_031334) do
     t.string "token"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "password_digest"
   end
 
   add_foreign_key "follows", "users", column: "followee_id"


### PR DESCRIPTION
## やったこと
・bcryptというgemをインストール→
これによりauthenticateメソッドとpassword_digestが使えるようになる。passwordとpassword_confirmationという２種類のフォームから受け取った値が一致すると、password_digestというハッシュ化された値が生成されるようになる。authenticateメソッドはハッシュ化されたpassword、つまりpassword_digestを認証できる特殊なメソッド。

・`password_digest:integer`をUserテーブルに追加→
実はpassword、password_confirmationはテーブル上のカラムには存在しない。フォームからその名前で受け取った値を確認した後に、`has_secure_password`によって自動生成されるのがpassword_digest、つまりUserテーブルに新たに追加されたカラム。

・current_userの定義を少しいじった。→
`@current_user ||= User.find_by(id: session[:user_id])`という書き方。これは、@current_userが存在していたらそれを返却、存在しなかったらUserモデルから検索という書き方で、毎回検索しに行く必要がなくなりパフォーマンス面で有利な書き方。

## 現状の課題・やるべきこと
・current_userをhelper_methodでappli_controllerに記述してるのに、Post#create内の`if !@current_user`で弾かれる。current_userがグローバルに正しく登録できてなさそう。ただ、ログイン時に`session[:user_id]`が正しく入ってることは確認済みなので、問題あるとしたらappli_controller？

・優先順位低いけど、User#create、User#login、Post#createあたりのアクションでストロングパラメーター導入したい。セキュリティ面の安心のため。