### PR TITLE
Feature/tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'acts-as-taggable-on', '6.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     bcrypt (3.1.15)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
@@ -150,6 +152,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (= 6.5.0)
   bcrypt (~> 3.1.12)
   bootsnap (>= 1.4.2)
   byebug

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,8 +5,8 @@ class PostsController < ApplicationController
     #postmanチェック済み（2020/09/07）
     @post = Post.new(content: params[:content], user_id: @current_user.id)
     #フロントからタグの名前の配列が来ることを想定（例：　tag_name: ["tag1", "tag2", ... , "tagn"]）
-    tag_names = params.permit(tag_name:[])
-    tag_names[:tag_name].each do |tag_name|
+    tag_names = params.permit(tag_names:[])
+    tag_names[:tag_names].each do |tag_name|
       @post.tag_list.add(tag_name)
     end
     @post.save

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,18 @@
 class PostsController < ApplicationController
 
   def create
-    puts @current_user
+    # puts @current_user
+    #postmanチェック済み（2020/09/07）
     @post = Post.new(content: params[:content], user_id: @current_user.id)
+    #フロントからタグの名前の配列が来ることを想定（例：　tag_name: ["tag1", "tag2", ... , "tagn"]）
+    tag_names = params.permit(tag_name:[])
+    tag_names[:tag_name].each do |tag_name|
+      @post.tag_list.add(tag_name)
+    end
     @post.save
-    render json: @post
+    render json: {
+        post: @post
+      }
   end
 
   def show

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  acts_as_taggable
+  
   belongs_to :user
   has_many :likes
 

--- a/db/migrate/20200906123652_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200906123652_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, %i[taggable_id taggable_type context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20200906123653_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200906123653_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, %i[taggable_id taggable_type context]
+    add_index :taggings,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, %i[taggable_id taggable_type context]
+  end
+end

--- a/db/migrate/20200906123654_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200906123654_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20200906123655_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200906123655_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+## This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, %i[taggable_id taggable_type context]
+  end
+
+  def self.down
+    remove_index :taggings, %i[taggable_id taggable_type context]
+  end
+end

--- a/db/migrate/20200906123656_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200906123656_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;") if ActsAsTaggableOn::Utils.using_mysql?
+  end
+end

--- a/db/migrate/20200906123657_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200906123657_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,19 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    add_index :taggings, %i[tagger_id tagger_type] unless index_exists? :taggings, %i[tagger_id tagger_type]
+
+    add_index :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy' unless index_exists? :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_072850) do
+ActiveRecord::Schema.define(version: 2020_09_06_123657) do
 
   create_table "follows", force: :cascade do |t|
     t.integer "follower_id"
@@ -32,6 +32,31 @@ ActiveRecord::Schema.define(version: 2020_08_27_072850) do
     t.integer "likes_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# タグ機能の実装
### やったこと
- posts#createにタグ機能を追加
- そのためにacts-as-taggable-onというgemを追加
- 付随してtagsテーブル（タグそのもののテーブル）とtaggingsテーブル（タグのリレーションのテーブル）を作成

### 留意点
- 今回タグ機能を作るにあたって、フロント側から受け取るタグに関するデータについては
　　　tag_names: ["tag1", "tag2", ...]
のような連想配列を想定した。
- 運営側がよく使われるであろうタグを予め用意しておくという話があったと思うが、それについては今のところフロント側の話なのかなと感じている。詳しくはわからないのでまたお話ししましょう。