### PR TITLE
Feature/create users#update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,7 @@ class UsersController < ApplicationController
   end
 
   def update
+    #postmanチェック済み（2020/09/09）
     @current_user.update_attributes(user_params)
     # 変更前のパスワードが入力されていたら
     if params[:old_password]
@@ -108,10 +109,7 @@ class UsersController < ApplicationController
       render json:{
         status: 403
       }
-<<<<<<< HEAD
     end
-=======
->>>>>>> 3e06245f4c305a0ae264c3fe5f94e7822f618ebe
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,8 +28,43 @@ class UsersController < ApplicationController
       user: @user,
       token: @user.token,
       posts: @posts,
-      liked_posts: @liked_posts #いいねした投稿の一覧表示
+      #いいねした投稿の一覧表示
+      liked_posts: @liked_posts
     }
+  end
+
+  def update
+    @current_user.update_attributes(user_params)
+    # 変更前のパスワードが入力されていたら
+    if params[:old_password]
+      # かつそのパスワードが正しかったら
+      if @current_user.authenticate(params[:old_password])
+        # パスワードを変更
+        @current_user.password = params[:new_password]
+        @current_user.password_confirmation = params[:new_password_confirmation]
+        # 新しいパスワードの保存に失敗した時
+        if !@current_user.save
+          render json:{
+            status: 400,
+            error_messages: @current_user.errors.full_messages
+          }
+        end
+      # パスワードが正しくなかったら
+      else
+        render json:{
+          status: 401
+        }
+      end
+    # 変更前のパスワードが入力されていなかったら
+    else
+      # パスワード以外の情報を保存し、それに失敗したら
+      if !@current_user.save
+        render json:{
+          status: 400,
+          error_messages: @current_user.errors.full_messages
+        }
+      end
+    end
   end
 
   def login
@@ -69,7 +104,7 @@ class UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:name, :uid, :password, :password_confirmation)
+    params.require(:user).permit(:name, :uid, :image_name, :profile, :password, :password_confirmation)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :check_user, only: :update
 
   def create
     #あとでuser_paramsに変える
@@ -100,6 +101,14 @@ class UsersController < ApplicationController
   def logout
     session[:user_id] = nil
     @current_user = nil
+  end
+
+  def check_user
+    if params[:id] != @current_user.id
+      render json:{
+        status: 403
+      }
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :check_user, only: :update
 
   def create
     #あとでuser_paramsに変える
@@ -100,6 +101,13 @@ class UsersController < ApplicationController
   def logout
     session[:user_id] = nil
     @current_user = nil
+  end
+
+  def check_user
+    if params[:id] != @current_user.id
+      render json:{
+        status: 403
+      }
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,8 @@ class User < ApplicationRecord
   # dependentの記述によって、
   # userが削除されると関連付いたpostsも全て削除される
   validates :name, {presence: true, length: {maximum: 20}}
-  validates :password, {presence: true, length: {in: 6..25}}
+  # ユーザ情報更新の際にパスワード入力なしでパスワード以外の情報を更新できるようにするためallow_nil: trueを追加
+  validates :password, {presence: true, length: {in: 6..25}, allow_nil: true}
   validates :uid, {presence: true, uniqueness: true, length: {in: 4..25}}
   validates :profile, {length: {maximum: 150}}
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
     post "users/create" => "users#create"
     get "users/:id" => "users#show"
+    post "users/:id/update" => "users#update"
     post "login" => "users#login"
     post "logout" => "users#logout"
 


### PR DESCRIPTION
# ユーザ情報編集のアクション（users#update）作成
### やったこと
- users#updateを作成し、ストロングパラメータを用いてユーザ情報を受け取り更新するようにした
- パスワードの入力の有無にかかわらず情報の更新ができるように、userモデルにallow_nil: trueを追加
- before_actionのcheck_userをusers#updateに対して追加、ログインユーザがログインユーザ以外のユーザの情報を編集しようとしたときにエラー（status: 403）を返す
- before_actionのauthenticate_userにusers#updateを追加