### PR TITLE
Feature/add follow counts into users

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -4,6 +4,10 @@ class FollowsController < ApplicationController
   def create
     #postmanチェック済み（2020/08/24）
     @follow = Follow.new(follower_id: @current_user.id, followee_id: params[:id])
+    # current_userのフォロー数を1増やす
+    User.find_by(id: @current_user.id).followee_count += 1
+    # フォローされたユーザのフォロワー数を1増やす
+    User.find_by(id: params[:id]).follower_count +=1
     @follow.save
     render json: @follow
   end
@@ -11,6 +15,10 @@ class FollowsController < ApplicationController
   def destroy
     #postmanチェック済み(2020/08/24)
     @follow = Follow.find_by(follower_id: @current_user.id, followee_id: params[:id])
+    # current_userのフォロー数を1減らす
+    User.find_by(id: @current_user.id).followee_count -= 1
+    # フォローされていたユーザのフォロワー数を1減らす
+    User.find_by(id: params[:id]).follower_count -= 1
     @follow.destroy
   end
 
@@ -38,7 +46,5 @@ class FollowsController < ApplicationController
       posts: @posts,
     }
   end
-  
+
 end
-
-

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user, only: [:show,　:update, :logout]
+  before_action :authenticate_user, only: [:show, :update, :logout]
   before_action :check_user, only: :update
 
   def create

--- a/db/migrate/20200909093704_add_follow_counts_to_users.rb
+++ b/db/migrate/20200909093704_add_follow_counts_to_users.rb
@@ -1,0 +1,6 @@
+class AddFollowCountsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :follower_count, :integer, default: 0
+    add_column :users, :followee_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_123657) do
+ActiveRecord::Schema.define(version: 2020_09_09_093704) do
 
   create_table "follows", force: :cascade do |t|
     t.integer "follower_id"
@@ -69,6 +69,8 @@ ActiveRecord::Schema.define(version: 2020_09_06_123657) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
+    t.integer "follower_count", default: 0
+    t.integer "followee_count", default: 0
   end
 
   add_foreign_key "follows", "users", column: "followee_id"


### PR DESCRIPTION
# フォロー数のカウントをusersテーブルに追加
### やったこと
- follower_countカラムとfollowee_countカラムをusersテーブルに追加（初期値: 0）
- follows#create（フォロー）、follows#destroy（フォロー解除）についてそのアクションが行われるたびにfollower_countとfollowee_countの値が増減するように変更

### ついでに・・・
- users_controllerのbefore_actionのauthenticate_userにあった軽微なバグ（空白の打ち間違い）を修正