### PR TITLE
fix render of follower#index and followee#index

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -23,15 +23,35 @@ class FollowsController < ApplicationController
   end
 
   def follower_index
-    #postmanチェック済み(2020/08/24)
+    #postmanチェック済み（2020/09/09）
+    # そのユーザ（:id）をフォローしているフォロー情報を最近フォローした順に取得
     @follows = Follow.where(followee_id: params[:id]).order('created_at DESC')
-    render json: @follows
+    @followers = Array.new
+    # フォロワーたちのユーザ情報を取得
+    @follows.each do |follow|
+      @followers.push(User.find_by(id: follow.follower_id))
+    end
+    # フォロワーたちの情報とフォロワー数を返す
+    render json: {
+      followers: @followers,
+      follower_count: @followers.count
+    }
   end
 
   def followee_index
-    #postmanチェック済み(2020/08/24)
+    #postmanチェック済み（2020/09/09）
+    # そのユーザ（:id）がフォローしているフォロー情報を最近フォローした順に取得
     @follows = Follow.where(follower_id: params[:id]).order('created_at DESC')
-    render json: @follows
+    @followees = Array.new
+    # フォローされている人たちのユーザ情報を取得
+    @follows.each do |follow|
+      @followees.push(User.find_by(id: follow.followee_id))
+    end
+    # フォローされている人たちの情報とフォロー数を返す
+    render json: {
+      followees: @followees,
+      followee_count: @followees.count
+    }
   end
 
   def timeline
@@ -43,7 +63,7 @@ class FollowsController < ApplicationController
     end
     @posts = Post.where(created_at: Time.current.ago(3.month)..Time.current, user_id: @followee_ids).order('created_at DESC')
     render json: {
-      posts: @posts,
+      posts: @posts
     }
   end
 


### PR DESCRIPTION
# follower#indexとfollowee#indexのrenderの修正
### やったこと
- renderで渡すデータをuser_idのみの情報からuserそのものの情報（名前、自己紹介文など）に変更、またfollower(ee)_countを追加してフォロワー（フォロー）数も渡すようにした

### 参考
- follower#indexで渡すJSONファイル例
![スクリーンショット 2020-09-09 23 47 27](https://user-images.githubusercontent.com/68543627/92614464-0c929b80-f2f7-11ea-8352-6d88c267a4a7.png)
- followee#indexで渡すJSONファイル例
![スクリーンショット 2020-09-09 23 48 34](https://user-images.githubusercontent.com/68543627/92614476-0f8d8c00-f2f7-11ea-86f6-404b9281d785.png)