### PR TITLE
Feature/fix follows#create and follows#destroy

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -54,7 +54,7 @@ class FollowsController < ApplicationController
     end
     @posts = Post.where(created_at: Time.current.ago(3.month)..Time.current, user_id: @followee_ids).order('created_at DESC')
     render json: {
-      posts: @posts,
+      posts: @posts
     }
   end
 

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -2,24 +2,35 @@ class FollowsController < ApplicationController
   before_action :authenticate_user
 
   def create
-    #postmanチェック済み（2020/08/24）
+    #postmanチェック済み（2020/09/10）
     @follow = Follow.new(follower_id: @current_user.id, followee_id: params[:id])
     # current_userのフォロー数を1増やす
-    User.find_by(id: @current_user.id).followee_count += 1
+    @current_user.followee_count += 1
+    @current_user.save
     # フォローされたユーザのフォロワー数を1増やす
-    User.find_by(id: params[:id]).follower_count +=1
+    followee = User.find_by(id: params[:id])
+    followee.follower_count += 1
+    followee.save
     @follow.save
-    render json: @follow
+    render json: {
+      user: @current_user
+    }
   end
 
   def destroy
-    #postmanチェック済み(2020/08/24)
+    #postmanチェック済み(2020/09/10)
     @follow = Follow.find_by(follower_id: @current_user.id, followee_id: params[:id])
     # current_userのフォロー数を1減らす
-    User.find_by(id: @current_user.id).followee_count -= 1
+    @current_user.followee_count -= 1
+    @current_user.save
     # フォローされていたユーザのフォロワー数を1減らす
-    User.find_by(id: params[:id]).follower_count -= 1
+    followee = User.find_by(id: params[:id])
+    followee.follower_count -= 1
+    followee.save
     @follow.destroy
+    render json: {
+      user: @current_user
+    }
   end
 
   def follower_index


### PR DESCRIPTION
# follows#create（フォロー）とfollows#destroy（フォロー解除）の修正
### やったこと
- createとdestroyの時のフォロー（フォロワー）数の増減がきちんと保存されるようにした
- JSONで渡すデータをcurrent_userにした（current_user内のfollowee_countカラムの内容が更新されているため）

### 参考
こんな感じでJSONファイルを返します
![スクリーンショット 2020-09-10 0 25 48](https://user-images.githubusercontent.com/68543627/92621045-4f0ba680-f2fe-11ea-8231-a4dcf876d2f0.png)