### PR TITLE
is_follow?の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::API
   end
 
   def is_follow?(user)
-    if Follow.find_by(follower_id: user.id, followee_id: @current_user)
+    if Follow.find_by(follower_id: @current_user, followee_id: user.id)
       return true
     else
       return false


### PR DESCRIPTION
- followee_idとfollower_idが逆になってました。
- currentUserが該当ユーザーをフォローしているかどうかを判別するものなので、followee_idが@current_userかと！