### PR TITLE
fix timezone to Japan

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,8 +32,12 @@ module Tanker
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
-    
+
     # trueをfalseに変更 by Lin
     config.api_only = false
+
+    # 標準時を日本時間に変更
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
# タイムゾーンの変更
### やったこと
- rails内の標準時を日本時間に合わせた（config.time_zone = "Tokyo"で）
- 登録される時間（created_atなど）をそのデータベースが動作するサーバの標準時に合わせた（日本のサーバなら日本時間）
（config.active_record.default_timezone = :localで）
