### PR TITLE
Feature/add redis rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'acts-as-taggable-on', '6.5.0'
 
 gem 'carrierwave', '~> 2.0'
+
+gem 'redis-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,23 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.2)
+    redis-actionpack (5.2.0)
+      actionpack (>= 5, < 7)
+      redis-rack (>= 2.1.0, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.2.0)
+      activesupport (>= 3, < 7)
+      redis-store (>= 1.3, < 2)
+    redis-rack (2.1.3)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.9.0)
+      redis (>= 4, < 5)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
     spring (2.1.1)
@@ -179,6 +196,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)
+  redis-rails
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/config/initializers/session_strore.rb
+++ b/config/initializers/session_strore.rb
@@ -1,0 +1,11 @@
+if Rails.env.production?
+  # 本番環境ではredisをsessionの保持に使う
+  Rails.application.config.session_store :redis_store,{
+    servers: ENV['REDIS_URL'],
+    expire_after: 1.week
+  }
+
+else
+  # それ以外の環境ではcookieを使う
+  Rails.application.config.session_store :cookie_store, expire_after: 1.week
+end


### PR DESCRIPTION
# redisの導入
### やったこと
- gemfileに'redis-rails'を追加、bundle installもした
- config/initializersディレクトリ下にsession_store.rbというファイルを追加、本番環境でredisが使われるように設定した

### 留意点
https://qiita.com/showwin/items/fa514fe45c26eae22a29
- だいぶ昔の投稿ではあるけど、上記のサイトにある通り、rails-apiのgemによってもう少し設定を追加しなければならないことがあるらしい。今のところgemfileにはrails-apiというgemはなかったのでこの設定はしなかったが、redisがうまく働かなかった場合はこれを試してみてもいいかもしれない