### PR TITLE
Postsモデルにlike_usersカラムを追加

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -49,6 +49,7 @@ class Api::PostsController < ApplicationController
       # いいねカウントを1増やす
       @post = Post.find_by(id: params[:id])
       @post.likes_count += 1
+      @post.like_users.push(@current_user.id)
       @post.save
       render json: {
         post: @post,
@@ -59,7 +60,7 @@ class Api::PostsController < ApplicationController
     else
       render json: {
         status: 409,
-        error_messages: @like.errors.full_messages
+        error_messages: @like.errors.full_mecssages
       }
     end
   end

--- a/db/migrate/20200926013431_add_likeusers_to_posts.rb
+++ b/db/migrate/20200926013431_add_likeusers_to_posts.rb
@@ -1,0 +1,5 @@
+class AddLikeusersToPosts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :posts, :like_users, :[]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_14_032733) do
+ActiveRecord::Schema.define(version: 2020_09_26_013431) do
 
   create_table "follows", force: :cascade do |t|
     t.integer "follower_id"
@@ -26,13 +26,8 @@ ActiveRecord::Schema.define(version: 2020_09_14_032733) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "posts", force: :cascade do |t|
-    t.string "content"
-    t.integer "user_id"
-    t.integer "likes_count", default: 0
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
+# Could not dump table "posts" because of following StandardError
+#   Unknown type '' for column 'like_users'
 
   create_table "taggings", force: :cascade do |t|
     t.integer "tag_id"


### PR DESCRIPTION
## やったこと
・Postsモデルにlike_usersというカラムを追加。
・posts#likeに下の処理を追記。
・これは配列型で、likeしたユーザーのidが追加される。

## 何がしたいのか
・like_statusの取得がうまくいかなかった。
・createLikeした時、jsonで返却されるpostsの中にlike_users配列があることで、その中にcurrentUser.idがあるかどうかでisLikeを判定できるようになる。