### PR TITLE
fix image_upload

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -198,7 +198,7 @@ class Api::UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:name, :uid, :profile, :password, :password_confirmation)
+    params.require(:user).permit(:name, :profile, :password, :password_confirmation)
   end
 
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -62,8 +62,12 @@ class Api::UsersController < ApplicationController
   # ユーザ情報の更新
   # パスワードの変更があるかないかで少し挙動が異なる
   def update
-    # image_nameタグにあるbase64にエンコードされた画像データを変換して上書き
-    params[:user][:image_name] = base64_conversion(params[:user][:image_name])
+    # 画像の変更がなされていたら、base64にエンコードされた画像データに変換して保存
+    if params[:user][:image_name].present?
+      params[:user][:image_name] = base64_conversion(params[:user][:image_name], SecureRandom.uuid)
+      @current_user.image_name = params[:user][:image_name]
+      @current_user.save
+    end
     # ここで予想されているパラメータは、"user": {"name": "hogehoge", "uid": "fugafuga", ...}の形
     # 変更前のパスワードが入力されていたら
     if params[:user][:old_password].present?
@@ -194,7 +198,7 @@ class Api::UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:name, :uid, :image_name, :profile, :password, :password_confirmation)
+    params.require(:user).permit(:name, :uid, :profile, :password, :password_confirmation)
   end
 
 end

--- a/app/uploaders/user_image_uploader.rb
+++ b/app/uploaders/user_image_uploader.rb
@@ -5,7 +5,7 @@ class UserImageUploader < CarrierWave::Uploader::Base
 
   # Choose what kind of storage to use for this uploader:
   if Rails.env.production?
-    strage :fog
+    storage :fog
   else
     storage :file
   end
@@ -58,7 +58,7 @@ class UserImageUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{SecureRandom.uuid}.jpg" if original_filename.present?
-  end
+  # def filename
+  #   "#{SecureRandom.uuid}.jpg" if original_filename.present?
+  # end
 end


### PR DESCRIPTION
# 画像アップロード機能の修正
### やったこと
- ユーザ情報の編集時（users#updateが呼ばれた時）に画像の更新がなされたかどうかで条件分岐をして個別に更新するようにした
- user_paramsからimage_nameとuidをなくした